### PR TITLE
Remove LPC1786 support

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -7,12 +7,6 @@
 [platformio]
 env_default = lpc11u24
 
-[env:lpc1768]
-platform = nxplpc
-framework = mbed
-board = lpc1768
-build_flags = -std=gnu++11
-
 [env:lpc11u24]
 platform = nxplpc
 framework = mbed


### PR DESCRIPTION
The current firmware probably won't run on it since we haven't tested
with it for a long time.