### PR TITLE
Don't use star dependency in Pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,4 +9,4 @@ python_version = "2.7"
 [dev-packages]
 
 [packages]
-platformio = "*"
+platformio = "~=3.5"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8032b6fa72e27cd16e5a9b10ae78279472ed2a39bdd96badf3c5189e88bc4991"
+            "sha256": "0fd7b5b911bf3d1753a5326958e16a4035bc0bad078fdd5fa532cc1d21b4e525"
         },
         "pipfile-spec": 6,
         "requires": {


### PR DESCRIPTION
That way it should be possible to just execute `pipenv update` without
breaking anything.