### PR TITLE
Fix JLink upload script

### DIFF
--- a/upload.jlink
+++ b/upload.jlink
@@ -1,4 +1,4 @@
 r
-loadbin ./.pioenvs/lpc11u24/firmware.bin 0x0000
+loadbin ./.pioenvs/debug/firmware.bin 0x0000
 r
 q


### PR DESCRIPTION
The environment was renamed in caa470539a2f601f3d031ceb12e9f6eb430a63f3.