### PR TITLE
Fix build by updating panic-semihosting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,6 @@ codegen-units = 1
 cortex-m = "0.5"
 cortex-m-rt = "0.5"
 cortex-m-semihosting = "0.3"
-panic-semihosting = "0.2"
+panic-semihosting = "0.3"
 lpc11uxx-hal = "0.1"
 embedded-hal = "0.2"


### PR DESCRIPTION
There was a breaking change in nighly:
https://users.rust-lang.org/t/psa-breaking-change-panic-fmt-language-item-removed-in-favor-of-panic-implementation/17875