### PR TITLE
Explicit clock configuration

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ fn main() -> ! {
 
     writeln!(stdout, "Initializing Delay").unwrap();
     let syst = p.SYST;
-    let rcc_config = hal::rcc::Config::default();
+    let rcc_config = hal::rcc::Config::msi(hal::rcc::MSIRange::Range5);
     let mut rcc = dp.RCC.freeze(rcc_config);
     let mut delay = hal::delay::Delay::new(syst, rcc.clocks);
 


### PR DESCRIPTION
This still results in the same configuration as using `Config::default()`, but it's now more explicit what's actually being used.