### PR TITLE
Implement HardwareVersionDetector

### DIFF
--- a/src/leds.rs
+++ b/src/leds.rs
@@ -1,3 +1,5 @@
+//! Controlling the status LEDs.
+
 use stm32l0xx_hal::prelude::*;
 use stm32l0xx_hal::{
     self as hal,

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,8 +10,12 @@ use stm32l0xx_hal::prelude::*;
 use stm32l0xx_hal::{self as hal, pac, serial, time};
 
 mod leds;
+mod version;
 
 use leds::{LedState, StatusLeds};
+use version::HardwareVersionDetector;
+
+const FIRMWARE_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[app(device = stm32l0::stm32l0x1, peripherals = true)]
 const APP: () = {
@@ -62,8 +66,21 @@ const APP: () = {
         )
         .unwrap();
 
-        writeln!(debug, "Greetings, Rusty world, from Gfrörli v2!").unwrap();
-        writeln!(debug, "Debug output initialized on USART1!").unwrap();
+        // Initialize version detector
+        let mut hardware_version = HardwareVersionDetector::new(
+            gpioa.pa12.into_floating_input(),
+            gpiob.pb4.into_floating_input(),
+            gpiob.pb5.into_floating_input(),
+        );
+
+        // Show versions
+        writeln!(
+            debug,
+            "Gfrörli firmware={} hardware={}",
+            FIRMWARE_VERSION,
+            hardware_version.detect(),
+        )
+        .unwrap();
 
         // Initialize LEDs
         let mut status_leds = StatusLeds::new(

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,9 +1,25 @@
 //! Detecting the hardware version.
 
+use core::fmt;
+
 use stm32l0xx_hal::gpio::gpioa::PA12;
 use stm32l0xx_hal::gpio::gpiob::{PB4, PB5};
 use stm32l0xx_hal::gpio::{Floating, Input};
 use stm32l0xx_hal::prelude::*;
+
+pub enum HardwareVersion {
+    V2,
+    Unknown(u8),
+}
+
+impl fmt::Display for HardwareVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::V2 => write!(f, "2.0"),
+            Self::Unknown(v) => write!(f, "v?({})", v),
+        }
+    }
+}
 
 pub struct HardwareVersionDetector {
     bit0: PA12<Input<Floating>>,
@@ -25,10 +41,18 @@ impl HardwareVersionDetector {
     }
 
     /// Detect the hardware version (number between 0 and 15).
-    pub fn detect(&mut self) -> u8 {
+    pub fn detect_raw(&mut self) -> u8 {
         let bit0 = self.bit0.is_high().unwrap() as u8;
         let bit1 = self.bit1.is_high().unwrap() as u8;
         let bit2 = self.bit2.is_high().unwrap() as u8;
         bit0 | (bit1 << 1) | (bit2 << 2)
+    }
+
+    /// Detect the hardware version.
+    pub fn detect(&mut self) -> HardwareVersion {
+        match self.detect_raw() {
+            0 => HardwareVersion::V2,
+            other => HardwareVersion::Unknown(other),
+        }
     }
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,0 +1,34 @@
+//! Detecting the hardware version.
+
+use stm32l0xx_hal::gpio::gpioa::PA12;
+use stm32l0xx_hal::gpio::gpiob::{PB4, PB5};
+use stm32l0xx_hal::gpio::{Floating, Input};
+use stm32l0xx_hal::prelude::*;
+
+pub struct HardwareVersionDetector {
+    bit0: PA12<Input<Floating>>,
+    bit1: PB4<Input<Floating>>,
+    bit2: PB5<Input<Floating>>,
+}
+
+impl HardwareVersionDetector {
+    pub fn new(
+        pa12: PA12<Input<Floating>>,
+        pb4: PB4<Input<Floating>>,
+        pb5: PB5<Input<Floating>>,
+    ) -> Self {
+        Self {
+            bit0: pa12,
+            bit1: pb4,
+            bit2: pb5,
+        }
+    }
+
+    /// Detect the hardware version (number between 0 and 15).
+    pub fn detect(&mut self) -> u8 {
+        let bit0 = self.bit0.is_high().unwrap() as u8;
+        let bit1 = self.bit1.is_high().unwrap() as u8;
+        let bit2 = self.bit2.is_high().unwrap() as u8;
+        bit0 | (bit1 << 1) | (bit2 << 2)
+    }
+}


### PR DESCRIPTION
A simple hardware version detector on PA12 / PB4 / PB5.

![2020-05-13-000222_735x627_scrot](https://user-images.githubusercontent.com/105168/81750024-0c9b9f80-94ad-11ea-9486-9c2cb89013e6.png)

Current output via serial:

![2020-05-13-000330_433x52_scrot](https://user-images.githubusercontent.com/105168/81750106-3359d600-94ad-11ea-8cbb-9f40a47cc120.png)

Should we keep the hardware version as an integer, or should I map it to an enum (where 0 would correspond to `V2_0` and others would correspond to `Unknown(u8)`)?