### PR TITLE
.embed.toml: Add reset target

### DIFF
--- a/.embed.toml
+++ b/.embed.toml
@@ -1,3 +1,5 @@
+# Chip and probe config
+
 [default.general]
 chip = "STM32L071KBTx"
 
@@ -5,9 +7,24 @@ chip = "STM32L071KBTx"
 protocol = "Swd"
 speed = 2500
 
+# Disable everything for default command
+
 [default.flashing]
 enabled = false
+
+[default.reset]
+enabled = false
+
+# Flash target
 
 [flash.flashing]
 enabled = true
 restore_unwritten_bytes = false
+
+[flash.reset]
+enabled = true
+
+# Reset target without flashing
+
+[reset.reset]
+enabled = true

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Use `cargo-embed` (0.8+):
 
     cargo embed flash --release
 
+To reset the target without flashing (requires `cargo-embed` 0.9+):
+
+    cargo embed reset
+
 
 ## License
 


### PR DESCRIPTION
(Requires https://github.com/probe-rs/cargo-embed/pull/27. The old
config will still parse properly, but nothing happens when using the
`reset` config.)