### PR TITLE
Add custom Tim7Delay

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
       - run: apt update -y
       - run: apt install -y gcc-arm-none-eabi
       - run: rustup target add thumbv6m-none-eabi
-      - run: cargo build --release
+      - run: cargo build --release --bins --examples
 
   fmt:
     docker:

--- a/examples/delay.rs
+++ b/examples/delay.rs
@@ -16,13 +16,13 @@ use gfroerli_firmware::delay;
 const APP: () = {
     #[init]
     fn init(ctx: init::Context) {
-        let dp: pac::Peripherals = ctx.device;
+        let mut dp: pac::Peripherals = ctx.device;
+
+        // Delay provider
+        let mut delay = delay::Tim7Delay::new(dp.TIM7, &mut dp.RCC);
 
         // Clock configuration. Use HSI at 16 MHz.
         let mut rcc = dp.RCC.freeze(hal::rcc::Config::hsi16());
-
-        // Delay provider
-        let mut delay = delay::Tim7Delay::new(dp.TIM7);
 
         // Toggle serial TX pin with delay
         let gpiob = dp.GPIOB.split(&mut rcc);

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -1,0 +1,101 @@
+//! Delay implementation using TIM7.
+//!
+//! This is done because RTIC takes ownership of SYST, and the stm32l0-hal by
+//! default also wants SYST for its Delay implementation.
+//!
+//! TODO: Move this into the HAL!
+
+use core::cmp::max;
+
+use embedded_hal::blocking::delay::{DelayMs, DelayUs};
+use stm32l0xx_hal::pac;
+
+pub struct Tim7Delay {
+    tim7: pac::TIM7,
+}
+
+impl Tim7Delay {
+    pub fn new(tim7: pac::TIM7) -> Self {
+        // Enable and reset TIM7 in RCC
+        //
+        // Correctness: Since we only modify TIM7 related registers in the RCC
+        // register block, and since we own pac::TIM7, we should be safe.
+        unsafe {
+            let rcc = &*pac::RCC::ptr();
+
+            // Enable timer
+            rcc.apb1enr.modify(|_, w| w.tim7en().set_bit());
+
+            // Reset timer
+            rcc.apb1rstr.modify(|_, w| w.tim7rst().set_bit());
+            rcc.apb1rstr.modify(|_, w| w.tim7rst().clear_bit());
+        }
+
+        // Enable one-pulse mode (counter stops counting at the next update
+        // event, clearing the CEN bit)
+        tim7.cr1.modify(|_, w| w.opm().enabled());
+
+        Self { tim7 }
+    }
+
+    pub fn free(self) -> pac::TIM7 {
+        self.tim7
+    }
+}
+
+fn wait(tim7: &mut pac::TIM7, prescaler: u16, auto_reload_register: u16) {
+    // Set up prescaler
+    //
+    // This implementation assumes that the core clock is set to 16 MHz (see
+    // `CORE_CLOCK` constant). At 16 MHz, this means 62.5 ns per clock cycle.
+    // By setting an appropriate prescaler, we can reduce the timer tick to the
+    // desired duration (e.g. 16 for 1 µs or 16_000 for 1 ms).
+    tim7.psc.write(|w| w.psc().bits(prescaler));
+
+    // Set the auto-reload register to the delay value
+    tim7.arr
+        .write(|w| unsafe { w.arr().bits(max(1, auto_reload_register)) });
+
+    // Trigger update event (UEV) in the event generation register (EGR)
+    // in order to immediately apply the config
+    tim7.egr.write(|w| w.ug().set_bit());
+
+    // Enable counter
+    tim7.cr1.modify(|_, w| w.cen().set_bit());
+
+    // Wait for CEN bit to clear
+    while tim7.cr1.read().cen().is_enabled() { /* wait */ }
+}
+
+/// Note that values below 4 µs are too short to be reliably measured using
+/// this implementation. The delay will always be at least ~4 µs long.
+impl DelayUs<u16> for Tim7Delay {
+    fn delay_us(&mut self, us: u16) {
+        // We have roughly 3 µs overhead. Note that this was only measured
+        // experimentally using a cheap logic analyzer and might be slightly off.
+        let overhead = 3;
+
+        // Subtract 1 from the ARR register because the update event is
+        // triggered *after* that tick.
+        wait(
+            &mut self.tim7,
+            16,
+            if us > overhead { us - overhead - 1 } else { 0 },
+        );
+    }
+}
+
+impl DelayMs<u16> for Tim7Delay {
+    fn delay_ms(&mut self, ms: u16) {
+        // If we set the ARR register to 0 (1-1), then the update event
+        // will never trigger. Therefore delegate to the `DelayUs` impl.
+        if ms <= 1 {
+            self.delay_us(ms * 1000);
+            return;
+        }
+
+        // Subtract 1 from the ARR register because the update event is
+        // triggered *after* that tick.
+        wait(&mut self.tim7, 16_000, ms - 1);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,3 @@
+#![no_std]
+
+pub mod delay;

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,10 @@ const APP: () = {
     #[init]
     fn init(ctx: init::Context) -> init::LateResources {
         let _p: cortex_m::Peripherals = ctx.core;
-        let dp: pac::Peripherals = ctx.device;
+        let mut dp: pac::Peripherals = ctx.device;
+
+        // Init delay timer
+        let mut delay = delay::Tim7Delay::new(dp.TIM7, &mut dp.RCC);
 
         // Clock configuration. Use HSI at 16 MHz.
         let mut rcc = dp.RCC.freeze(hal::rcc::Config::hsi16());
@@ -62,9 +65,6 @@ const APP: () = {
         //let mut rcc = dp.RCC.freeze(
         //    hal::rcc::Config::msi(hal::rcc::MSIRange::Range5) // ~2.097 MHz
         //);
-
-        // Init delay timer
-        let mut delay = delay::Tim7Delay::new(dp.TIM7);
 
         // Initialize timer to blink LEDs. Use TIM6 since it has lower current
         // consumption than TIM2/3 or TIM21/22.


### PR DESCRIPTION
The HAL delay uses the systick timer (SYST). This timer is not available anymore when using RTIC with the scheduler.

Here's an implementation of DelayUs and DelayMs for TIM7 (with busy-looping until the update event of the timer is reached). It seems to work, although delays lower than ~4 µs cannot be achieved.

![2020-08-21-010458_1813x523_scrot](https://user-images.githubusercontent.com/105168/90834349-5f0d1780-e34a-11ea-8ae0-b40e9a55e8e7.png)

The precision seems to be good enough for one-wire to work:

![image](https://user-images.githubusercontent.com/105168/90834531-c925bc80-e34a-11ea-8fb6-39d3977f57d9.png)

Busy-looping was the easiest approach and works, but seems a bit wasteful. Is this busy-looping standard practice? Would it be better to schedule an interrupt and WFI during looping? (I'm not sure if this could be implemented cleanly in a standalone implementation because interrupt handling ist done by RTIC...)

I think in our case it should be fine because we only use the blocking delay for very short intervals during things like one wire communication.