### PR TITLE
Add unit test support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ jobs:
       - run: apt install -y gcc-arm-none-eabi
       - run: rustup target add thumbv6m-none-eabi
       - run: cargo build --release --bins --examples
+      - run: cargo test --target x86_64-unknown-linux-gnu --tests
 
   fmt:
     docker:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,9 @@ cortex-m-rtic = "0.5"
 ds18b20 = "0.1.0"
 embedded-hal = { version = "0.2.2", features = ["unproven"] }
 one-wire-bus = "0.1.1"
-panic-halt = "0.2" # Use ITM or panic-persist in the future
 stm32l0 = "0.10.0"
 stm32l0xx-hal = { git = "ssh://git@github.com/stm32-rs/stm32l0xx-hal.git", branch = "master", features = ["rt", "mcu-STM32L071KBTx"] }
 shtcx = { git = "https://github.com/dbrgn/shtcx-rs", branch = "master" }
+
+[target.'cfg(target_arch = "arm")'.dependencies]
+panic-halt = "0.2" # Use ITM or panic-persist in the future

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,3 @@
-#![no_std]
-
+#![cfg_attr(not(test), no_std)]
 pub mod delay;
+pub mod supply_monitor;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 #![no_main]
 #![no_std]
+#![cfg(target_arch = "arm")]
 
 extern crate panic_halt;
 

--- a/src/supply_monitor.rs
+++ b/src/supply_monitor.rs
@@ -62,3 +62,19 @@ impl SupplyMonitor {
         (input as f32) / ADC_MAX * SUPPLY_VOLTAGE / R_1 * (R_1 + R_2)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_convert_input() {
+        let inputs = [0, 2047, 4095];
+        let results = [0.0, 2.72, 5.44];
+        for (input, expected) in inputs.iter().zip(&results) {
+            let result = SupplyMonitor::convert_input(*input);
+            println!("{} -> {}, should {}", input, result, expected);
+            assert!((result - *expected).abs() < 0.01);
+        }
+    }
+}


### PR DESCRIPTION
By compiling the binary and the panic-halt dependency only when
compiling for arm and only declaring no_std when not in test mode, we
allow for regular unit tests to be run on the host.