### PR TITLE
Call miniterm through Python

### DIFF
--- a/serial-debug.sh
+++ b/serial-debug.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 set -eu
-miniterm.py --raw --echo /dev/ttyUSB0 57600
+python3 -m serial.tools.miniterm --raw --echo /dev/ttyUSB0 57600


### PR DESCRIPTION
In newer releases, the python-serial package does not build the
`miniterm.py` binary anymore.

Instead, access miniterm through `python3 -m serial.tools.miniterm`.