### PR TITLE
Switch from panic-halt to panic-persist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ dependencies = [
  "cortex-m-rtic 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "embedded-hal 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "one-wire-bus 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "panic-halt 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "panic-persist 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "shtcx 0.9.0 (git+https://github.com/dbrgn/shtcx-rs)",
  "stm32l0 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "stm32l0xx-hal 0.6.2 (git+ssh://git@github.com/stm32-rs/stm32l0xx-hal.git)",
@@ -192,9 +192,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "panic-halt"
-version = "0.2.0"
+name = "panic-persist"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cortex-m 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -358,7 +361,7 @@ dependencies = [
 "checksum indexmap 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c398b2b113b55809ceb9ee3e753fcbac793f1956663f3c36549c1346015c2afe"
 "checksum nb 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b1411551beb3c11dedfb0a90a0fa256b47d28b9ec2cdff34c25a2fa59e45dbdc"
 "checksum one-wire-bus 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a9761e13074f8f916702c1a1dbe0eda3fb8478704db00493f5a5c27ed5847710"
-"checksum panic-halt 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de96540e0ebde571dc55c73d60ef407c653844e6f9a1e2fdbd40c07b9252d812"
+"checksum panic-persist 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dd2e692a5954e3eb0c16f5dbaa75c4332a78d85851521f138c04ad95d6f5ee42"
 "checksum proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
 "checksum quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "54a21852a652ad6f610c9510194f398ff6f8692e334fd1145fed931f7fbe44ea"
 "checksum r0 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e2a38df5b15c8d5c7e8654189744d8e396bddc18ad48041a500ce52d6948941f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ shtcx = { git = "https://github.com/dbrgn/shtcx-rs", branch = "master" }
 bitfield = "0.13"
 
 [target.'cfg(target_arch = "arm")'.dependencies]
-panic-halt = "0.2" # Use ITM or panic-persist in the future
+panic-persist = { version = "0.2", features = ["utf8"] }
 
 [features]
 # Enable some more verbose logging and debug assertions

--- a/examples/delay.rs
+++ b/examples/delay.rs
@@ -4,8 +4,7 @@
 #![no_main]
 #![no_std]
 
-extern crate panic_halt;
-
+use panic_persist as _;
 use rtic::app;
 use stm32l0xx_hal::prelude::*;
 use stm32l0xx_hal::{self as hal, pac};

--- a/memory.x
+++ b/memory.x
@@ -2,10 +2,15 @@ MEMORY
 {
   /* NOTE K = KiBi = 1024 bytes */
   FLASH : ORIGIN = 0x08000000, LENGTH = 128K
-  RAM : ORIGIN = 0x20000000, LENGTH = 20K
+  RAM : ORIGIN = 0x20000000, LENGTH = 19K
+  PANDUMP : ORIGIN = 0x20004C00, LENGTH = 1K
 }
 
 /* This is where the call stack will be allocated. */
 /* The stack is of the full descending type. */
 /* NOTE Do NOT modify `_stack_start` unless you know what you are doing */
 _stack_start = ORIGIN(RAM) + LENGTH(RAM);
+
+/* Information required for panic-persist. */
+_panic_dump_start = ORIGIN(PANDUMP);
+_panic_dump_end   = ORIGIN(PANDUMP) + LENGTH(PANDUMP);


### PR DESCRIPTION
On boot, when a panic message is found, print it to serial and carry on.

![panic_000](https://user-images.githubusercontent.com/105168/103711150-0f588100-4fb7-11eb-8cfa-c09dbf7ccc73.png)
