### PR TITLE
monotonic impl: Fix panic due to timer rollover

### DIFF
--- a/firmware/src/monotonic_stm32l0.rs
+++ b/firmware/src/monotonic_stm32l0.rs
@@ -146,7 +146,7 @@ impl Instant {
 
     /// Returns the amount of time elapsed from another instant to this one.
     pub fn duration_since(&self, earlier: Instant) -> Duration {
-        let diff = self.inner - earlier.inner;
+        let diff = self.inner.wrapping_sub(earlier.inner);
         assert!(diff >= 0, "second instant is later than self");
         Duration { inner: diff as u16 }
     }


### PR DESCRIPTION
After the timer value rolls over the newer more recent value will be
negative. Calculating the duration_since with an older still positive
Instant results in a panic due to subtracting with overflow:

panicked at 'attempt to subtract with overflow', src/monotonic_stm32l0.rs:149:20

Fixes #96 

See also https://github.com/rtic-rs/rtic-examples/commit/beabbe39d5c4bb37c8c453de704aeba0b8c118b0