### PR TITLE
Send actual voltage as part of measurement

### DIFF
--- a/firmware/src/measurement.rs
+++ b/firmware/src/measurement.rs
@@ -7,6 +7,11 @@ impl U12 {
     pub fn new(value: u16) -> Self {
         Self(value.min(0xFFF))
     }
+
+    /// Return the inner u16 (with the 4 uppermost bits set to 0).
+    pub fn as_u16(&self) -> u16 {
+        self.0
+    }
 }
 
 pub const MAX_MSG_LEN: usize = 8;


### PR DESCRIPTION
Additionally, the data printing has been refactored and simplified using the `delimit!` macro.

Fixes #93.

Marked as draft because I could not test this yet. However, the PR can already be reviewed!