### PR TITLE
Fix typo in crate documentation

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,4 +1,4 @@
 #![cfg_attr(not(test), no_std)]
-//! This crate holds all code which is used in the gfroerli firmare and command line utilities.
+//! This crate holds all code which is used in the gfroerli firmware and command line utilities.
 
 pub mod config;


### PR DESCRIPTION
Got a bad reviewer last time :wink: 