### PR TITLE
RTC wakeup counter

### DIFF
--- a/firmware/Cargo.lock
+++ b/firmware/Cargo.lock
@@ -44,7 +44,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5deb64efa5bd81e31fcd1938615a6d98c82eafcbcd787162b6f63b91d6bac5b3"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.2.3",
 ]
 
 [[package]]
@@ -71,8 +71,14 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.2.3",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
@@ -239,6 +245,7 @@ dependencies = [
  "one-wire-bus",
  "panic-persist",
  "rn2xx3",
+ "rstest",
  "shtcx",
  "stm32l0xx-hal",
 ]
@@ -384,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.26"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
+checksum = "fb37d2df5df740e582f28f8560cf425f52bb267d872fe58358eadb554909f07a"
 dependencies = [
  "unicode-xid",
 ]
@@ -417,6 +424,19 @@ dependencies = [
  "embedded-hal",
  "nb 0.1.3",
  "numtoa",
+]
+
+[[package]]
+name = "rstest"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2288c66aeafe3b2ed227c981f364f9968fa952ef0b30e84ada4486e7ee24d00a"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.0",
+ "syn",
 ]
 
 [[package]]
@@ -451,7 +471,16 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver",
+ "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver 1.0.4",
 ]
 
 [[package]]
@@ -462,6 +491,12 @@ checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
  "semver-parser",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "semver-parser"
@@ -516,9 +551,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.68"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ce15dd3ed8aa2f8eeac4716d6ef5ab58b6b9256db41d7e1a0224c2788e8fd87"
+checksum = "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/firmware/Cargo.lock
+++ b/firmware/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19796bd8d477f1a9d4ac2465b464a8b1359474f06a96bb3cda650b4fca309bf"
 dependencies = [
- "as-slice",
+ "as-slice 0.1.5",
 ]
 
 [[package]]
@@ -20,6 +20,15 @@ dependencies = [
  "generic-array 0.12.4",
  "generic-array 0.13.3",
  "generic-array 0.14.4",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
  "stable_deref_trait",
 ]
 
@@ -63,6 +72,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0"
 dependencies = [
  "rustc_version",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -163,6 +182,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-time"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a4b4d10ac48d08bfe3db7688c402baadb244721f30a77ce360bd24c3dffe58"
+dependencies = [
+ "num",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,16 +230,16 @@ name = "gfroerli-firmware"
 version = "0.2.0"
 dependencies = [
  "bitfield",
- "cortex-m 0.6.7",
+ "cortex-m 0.7.2",
  "cortex-m-rt",
  "cortex-m-rtic",
  "embedded-hal",
+ "embedded-time",
  "gfroerli-common",
  "one-wire-bus",
  "panic-persist",
  "rn2xx3",
  "shtcx",
- "stm32l0",
  "stm32l0xx-hal",
 ]
 
@@ -236,7 +264,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "634bd4d29cbf24424d0a4bfcbf80c6960129dc24424752a7d1d1390607023422"
 dependencies = [
- "as-slice",
+ "as-slice 0.1.5",
  "generic-array 0.14.4",
  "hash32",
  "stable_deref_trait",
@@ -268,6 +296,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
 
 [[package]]
+name = "num"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b7a8e9be5e039e2ff869df49155f1c06bd01ade2117ec783e56ab0932b67a8f"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747d632c0c558b87dbabbe6a82f3b4ae03720d0646ac5b7b4dae89394be5f2c5"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "numtoa"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,11 +375,11 @@ dependencies = [
 
 [[package]]
 name = "panic-persist"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd2e692a5954e3eb0c16f5dbaa75c4332a78d85851521f138c04ad95d6f5ee42"
+checksum = "32bb382689ecd2c4d2d4df9fd56700ba8d43b7b31cca11018cc0e6f8aef39fd5"
 dependencies = [
- "cortex-m 0.6.7",
+ "cortex-m 0.7.2",
 ]
 
 [[package]]
@@ -326,6 +417,15 @@ dependencies = [
  "embedded-hal",
  "nb 0.1.3",
  "numtoa",
+]
+
+[[package]]
+name = "rtcc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef35f9dcbf434a34dcc99b3ebba1c1945d49c70832958e932e83dc63a5273994"
+dependencies = [
+ "chrono",
 ]
 
 [[package]]
@@ -385,28 +485,31 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "stm32l0"
-version = "0.10.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8386ff55bd099b3c6c7ea16bb68296cbe6025981f96ed69b222b6e6633ca6148"
+checksum = "ed7ffdb929148070435dbc4dc69fd62b3a031c0543b4a9d2ec9fc8b31a0f3344"
 dependencies = [
  "bare-metal",
- "cortex-m 0.6.7",
+ "cortex-m 0.7.2",
  "cortex-m-rt",
  "vcell",
 ]
 
 [[package]]
 name = "stm32l0xx-hal"
-version = "0.7.0"
-source = "git+ssh://git@github.com/stm32-rs/stm32l0xx-hal.git?branch=master#8bb5d3c989dc55a82cc7ef746cf0c27a4cf1bbe8"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "795b63c22675365ba0cb6d9bd3b8aca86e1704b9d4a527c6301f9f259a15cbaf"
 dependencies = [
- "as-slice",
+ "as-slice 0.2.1",
  "cast",
- "cortex-m 0.6.7",
+ "cortex-m 0.7.2",
  "cortex-m-rt",
  "cortex-m-semihosting",
  "embedded-hal",
- "nb 0.1.3",
+ "embedded-time",
+ "nb 1.0.0",
+ "rtcc",
  "stm32l0",
  "void",
 ]

--- a/firmware/Cargo.toml
+++ b/firmware/Cargo.toml
@@ -26,6 +26,9 @@ rn2xx3 = "0.2.1"
 stm32l0xx-hal = { version = "0.8.0", features = ["rt", "mcu-STM32L071KBTx", "rtc"] }
 shtcx = { git = "https://github.com/dbrgn/shtcx-rs", branch = "master" }
 
+[dev-dependencies]
+rstest = "0.11"
+
 [target.'cfg(target_arch = "arm")'.dependencies]
 panic-persist = { version = "0.3.0", features = ["utf8"] }
 

--- a/firmware/Cargo.toml
+++ b/firmware/Cargo.toml
@@ -16,18 +16,18 @@ edition = "2021"
 gfroerli-common = { path = "../common" }
 
 bitfield = "0.13"
-cortex-m = "0.6"
-cortex-m-rt = "0.6"
+cortex-m = "0.7" # Keep in sync with stm32l0xx-hal
+cortex-m-rt = "0.6.8" # Keep in sync with stm32l0xx-hal
 cortex-m-rtic = "0.5"
-embedded-hal = { version = "0.2.2", features = ["unproven"] }
+embedded-hal = { version = "0.2.3", features = ["unproven"] } # Keep in sync with stm32l0xx-hal
+embedded-time = "0.12" # Keep in sync with stm32l0xx-hal
 one-wire-bus = "0.1.1"
 rn2xx3 = "0.2.1"
-stm32l0 = "0.10.0"
-stm32l0xx-hal = { git = "ssh://git@github.com/stm32-rs/stm32l0xx-hal.git", branch = "master", features = ["rt", "mcu-STM32L071KBTx"] }
+stm32l0xx-hal = { version = "0.8.0", features = ["rt", "mcu-STM32L071KBTx", "rtc"] }
 shtcx = { git = "https://github.com/dbrgn/shtcx-rs", branch = "master" }
 
 [target.'cfg(target_arch = "arm")'.dependencies]
-panic-persist = { version = "0.2", features = ["utf8"] }
+panic-persist = { version = "0.3.0", features = ["utf8"] }
 
 [features]
 # Enable some more verbose logging and debug assertions

--- a/firmware/examples/delay.rs
+++ b/firmware/examples/delay.rs
@@ -6,12 +6,11 @@
 
 use panic_persist as _;
 use rtic::app;
-use stm32l0xx_hal::prelude::*;
-use stm32l0xx_hal::{self as hal, pac};
+use stm32l0xx_hal::{self as hal, pac, prelude::*};
 
 use gfroerli_firmware::delay;
 
-#[app(device = stm32l0::stm32l0x1, peripherals = true)]
+#[app(device = stm32l0xx_hal::pac, peripherals = true)]
 const APP: () = {
     #[init]
     fn init(ctx: init::Context) {

--- a/firmware/src/delay.rs
+++ b/firmware/src/delay.rs
@@ -46,7 +46,7 @@ fn wait(tim7: &mut pac::TIM7, prescaler: u16, auto_reload_register: u16) {
 
     // Set the auto-reload register to the delay value
     tim7.arr
-        .write(|w| unsafe { w.arr().bits(max(1, auto_reload_register)) });
+        .write(|w| w.arr().bits(max(1, auto_reload_register)));
 
     // Trigger update event (UEV) in the event generation register (EGR)
     // in order to immediately apply the config

--- a/firmware/src/leds.rs
+++ b/firmware/src/leds.rs
@@ -1,26 +1,25 @@
 //! Controlling the status LEDs.
 
-use stm32l0xx_hal::prelude::*;
 use stm32l0xx_hal::{
-    self as hal,
-    gpio::{Output, PushPull},
+    gpio::{Output, Pin, PushPull},
+    prelude::*,
 };
 
 /// Status LEDs.
 pub struct StatusLeds {
     /// Red status LED
-    led_r: hal::gpio::gpiob::PB<Output<PushPull>>,
+    led_r: Pin<Output<PushPull>>,
     /// Yellow status LED
-    led_y: hal::gpio::gpiob::PB<Output<PushPull>>,
+    led_y: Pin<Output<PushPull>>,
     /// Green status LED
-    led_g: hal::gpio::gpioa::PA<Output<PushPull>>,
+    led_g: Pin<Output<PushPull>>,
 }
 
 impl StatusLeds {
     pub fn new(
-        led_r: hal::gpio::gpiob::PB<Output<PushPull>>,
-        led_y: hal::gpio::gpiob::PB<Output<PushPull>>,
-        led_g: hal::gpio::gpioa::PA<Output<PushPull>>,
+        led_r: Pin<Output<PushPull>>,
+        led_y: Pin<Output<PushPull>>,
+        led_g: Pin<Output<PushPull>>,
     ) -> Self {
         Self {
             led_r,

--- a/firmware/src/lib.rs
+++ b/firmware/src/lib.rs
@@ -1,3 +1,4 @@
 #![cfg_attr(not(test), no_std)]
 pub mod delay;
+pub mod rtc;
 pub mod supply_monitor;

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -16,7 +16,7 @@ use stm32l0xx_hal::gpio::{
     OpenDrain, Output,
 };
 use stm32l0xx_hal::prelude::*;
-use stm32l0xx_hal::{self as hal, i2c::I2c, pac, serial, time};
+use stm32l0xx_hal::{self as hal, i2c::I2c, pac, pwr, rtc, serial, time};
 
 // First party crates
 use gfroerli_common::config::{self, Config};
@@ -77,6 +77,9 @@ const APP: () = {
 
         // Blocking delay provider
         delay: Tim7Delay,
+
+        // Real-time clock
+        rtc: rtc::RTC,
     }
 
     #[init(spawn = [start_measurements], schedule = [disable_leds])]
@@ -101,6 +104,12 @@ const APP: () = {
         // Initialize monotonic timer TIM6. Use TIM6 since it has lower current
         // consumption than TIM2/3 or TIM21/22.
         Tim6Monotonic::initialize(dp.TIM6);
+
+        // Get access to PWR peripheral
+        let pwr = pwr::PWR::new(dp.PWR, &mut rcc);
+
+        // Instantiate RTC peripheral
+        let rtc = rtc::RTC::new(dp.RTC, &mut rcc, &pwr, rtc::Instant::new());
 
         // Get access to GPIOs
         let gpioa = dp.GPIOA.split(&mut rcc);
@@ -360,6 +369,7 @@ const APP: () = {
             rn,
             supply_monitor,
             delay,
+            rtc,
         }
     }
 

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -109,7 +109,7 @@ const APP: () = {
         let pwr = pwr::PWR::new(dp.PWR, &mut rcc);
 
         // Instantiate RTC peripheral
-        let rtc = rtc::RTC::new(dp.RTC, &mut rcc, &pwr, rtc::Instant::new());
+        let mut rtc = rtc::RTC::new(dp.RTC, &mut rcc, &pwr, rtc::Instant::new());
 
         // Get access to GPIOs
         let gpioa = dp.GPIOA.split(&mut rcc);
@@ -154,7 +154,7 @@ const APP: () = {
         // Show versions
         writeln!(
             debug,
-            "Booting: Gfrörli firmware={} hardware={}",
+            "\n🚀 Booting: Gfrörli firmware={} hardware={}",
             FIRMWARE_VERSION,
             hardware_version.detect(),
         )
@@ -209,10 +209,27 @@ const APP: () = {
             Ok(c) => c,
             Err(e) => panic!("Error: Could not read config from EEPROM: {}", e),
         };
-        writeln!(debug, "Loaded config (v{}) from EEPROM", config.version).unwrap();
+        writeln!(debug, "🔧 Loaded config (v{}) from EEPROM", config.version).unwrap();
         if cfg!(feature = "dev") {
             writeln!(debug, "Config: {:?}", config).unwrap();
         }
+
+        // Measure current time to determine the wakeup cycle
+        let now = rtc.now();
+        writeln!(
+            debug,
+            "📅 Date: {:04}-{:02}-{:02} {:02}:{:02}:{:02}",
+            now.year(),
+            now.month(),
+            now.day(),
+            now.hour(),
+            now.minute(),
+            now.second()
+        )
+        .unwrap();
+
+        // End of header
+        writeln!(debug).unwrap();
 
         // Initialize supply monitor
         let adc = dp.ADC.constrain(&mut rcc);

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -35,6 +35,7 @@ mod delay;
 mod ds18b20;
 mod leds;
 mod monotonic_stm32l0;
+mod rtc;
 mod supply_monitor;
 mod version;
 
@@ -226,13 +227,14 @@ const APP: () = {
         let now = rtc.now();
         writeln!(
             debug,
-            "📅 Date: {:04}-{:02}-{:02} {:02}:{:02}:{:02}",
+            "📅 RTC Date: {:04}-{:02}-{:02} {:02}:{:02}:{:02} (Uptime: {}s)",
             now.year(),
             now.month(),
             now.day(),
             now.hour(),
             now.minute(),
-            now.second()
+            now.second(),
+            rtc::datetime_to_uptime(now),
         )
         .unwrap();
 

--- a/firmware/src/rtc.rs
+++ b/firmware/src/rtc.rs
@@ -1,0 +1,66 @@
+//! RTC related helper functions.
+use stm32l0xx_hal::rtc::{Datelike, NaiveDateTime, Timelike};
+
+/// Takes a `datetime` and returns the seconds of uptime.
+///
+/// This could also be implemented by doing `(dt2 - dt1).num_seconds()`, but
+/// that would involve 64 bit arithmetic in Chrono which does not perform well
+/// on a 32 bit microcontroller. Instead, this implementation fully works with
+/// 32 bit integer arithmetic, because we only need to support a certain year
+/// range, and need no subsecond precision.
+///
+/// Note: The RTC is initialized to 2001-01-01 00:00:00.
+pub fn datetime_to_uptime(dt: NaiveDateTime) -> u32 {
+    let h = 3_600;
+    let d = 24 * h;
+    let y = 365 * d;
+
+    // We need to get the number of full leap years since 2001. (Partial leap
+    // years can be ignored because we use `.ordinal0()` which considers leap
+    // years.) The first leap year after 2001 is 2004, thus we can use the
+    // following calculation:
+    //
+    //     ceil((year - 2004) / 4)
+    //
+    // Unfortunately Rust doesn't have stable ceiling division yet. To avoid
+    // floating point operations, add 4-1 to the year before dividing by 4.
+    //
+    // Note: This assumes that every 4th year is a leap year. This will work
+    // for all years between 2001 and 2099.
+    let full_leap_years = ((dt.year() as u32).saturating_sub(2004) + 3) / 4;
+
+    let full_year_seconds = (dt.year() as u32 - 2001) * y + full_leap_years * d;
+    let full_day_seconds = dt.ordinal0() * d;
+    let current_day_seconds = dt.num_seconds_from_midnight();
+
+    full_year_seconds + full_day_seconds + current_day_seconds
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use rstest::rstest;
+    use stm32l0xx_hal::rtc::NaiveDate;
+
+    #[rstest]
+    #[case(NaiveDate::from_ymd(2001, 1, 1).and_hms(0, 0, 0), 0)]
+    #[case(NaiveDate::from_ymd(2001, 1, 1).and_hms(0, 0, 3), 3)]
+    #[case(NaiveDate::from_ymd(2001, 1, 1).and_hms(20, 10, 59), 72_659)]
+    #[case(NaiveDate::from_ymd(2003, 2, 3).and_hms(7, 0, 5), 65_948_405)]
+    fn test_datetime_to_uptime_predefined(
+        #[case] datetime: NaiveDateTime,
+        #[case] expected_seconds: u32,
+    ) {
+        assert_eq!(datetime_to_uptime(datetime), expected_seconds);
+    }
+
+    #[test]
+    fn test_datetime_to_uptime_vs_builtin() {
+        let reference = NaiveDate::from_ymd(2001, 1, 1).and_hms(0, 0, 0);
+        let datetime = NaiveDate::from_ymd(2098, 11, 28).and_hms(13, 14, 15);
+        let chrono_builtin = (datetime - reference).num_seconds();
+        let gfroerli_firmware = datetime_to_uptime(datetime);
+        assert_eq!(gfroerli_firmware as i64, chrono_builtin);
+    }
+}

--- a/firmware/src/supply_monitor.rs
+++ b/firmware/src/supply_monitor.rs
@@ -1,8 +1,8 @@
-use embedded_hal::adc::OneShot;
-use embedded_hal::digital::v2::OutputPin;
-use stm32l0xx_hal::adc::{self, Adc, Align};
-use stm32l0xx_hal::gpio::gpioa::{PA, PA1};
-use stm32l0xx_hal::gpio::{Analog, Output, PushPull};
+use embedded_hal::{adc::OneShot, digital::v2::OutputPin};
+use stm32l0xx_hal::{
+    adc::{self, Adc, Align},
+    gpio::{gpioa::PA1, Analog, Output, Pin, PushPull},
+};
 
 use gfroerli_common::measurement::U12;
 
@@ -10,14 +10,14 @@ use gfroerli_common::measurement::U12;
 pub struct SupplyMonitor {
     adc_pin: PA1<Analog>,
     adc: Adc<adc::Ready>,
-    enable_pin: PA<Output<PushPull>>,
+    enable_pin: Pin<Output<PushPull>>,
 }
 
 impl SupplyMonitor {
     pub fn new(
         adc_pin: PA1<Analog>,
         mut adc: Adc<adc::Ready>,
-        enable_pin: PA<Output<PushPull>>,
+        enable_pin: Pin<Output<PushPull>>,
     ) -> Self {
         adc.set_precision(adc::Precision::B_12);
         adc.set_align(Align::Right); // Use 12 least-significant bits to encode data


### PR DESCRIPTION
Changes:

- [x] HAL: Upgrade to `rtc` branch based on latest master
- [x] Ensure that the external crystal (LSE) is used for timekeeping
- [x] Calculate uptime based on RTC time
- [x] Implement wakeup counter based on uptime

The initialization value is `2001-01-01 00:00:00`. (We don't need a correct absolute datetime, we just need to measure elapsed time.) The RTC keeps its time as long as the power is not removed.

When starting, the RTC datetime and the uptime is printed to serial, followed by the config and base measurement plan:

![screenshot-20211209-232551](https://user-images.githubusercontent.com/105168/145485490-d02235ad-b8c6-45e9-9fc8-523cba776ddb.png)

The wakeup cycle is calculated by using `uptime_seconds // wakeup_interval_seconds`. For every measurement type, the appropriate `wakeup_cycle % nth_XXX == 0` calculation is done. If it's 0, the measurement is enabled in the base measurement plan. (The base measurement plan may be modified later based on availability of sensors.)

Refs #72.