### PR TITLE
Fix panic in scheduler due to potential timer overflow

### DIFF
--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -537,7 +537,7 @@ const APP: () = {
         // Re-schedule a measurement
         // (TODO: Go to sleep here)
         ctx.schedule
-            .start_measurements(ctx.scheduled + 5000.millis())
+            .start_measurements(ctx.scheduled + 4000.millis())
             .unwrap();
     }
 


### PR DESCRIPTION
Previously the code panicked when re-scheduling a measurement:

    panicked at 'assertion failed: dur.inner < (1 << 15)', src/monotonic_stm32l0.rs:167:9

The reason is that we're scheduling the next measurement 5000ms into the
future:

    ctx.schedule
        .start_measurements(ctx.scheduled + 5000.millis())

Unfortunately our 16bit timer cannot do this:

> Because the timer has 16 bits, it will overflow every 125 µs * 2^16 =
> ~8.19 seconds. Due to overflow checking, we can only safely use one
> half of the available timer range, meaning that we can safely schedule
> tasks 4.096 seconds into the future, with a resolution of 125 µs.

Thus, reduce the timeout to 4s. In the future, we'll use the RTC to
schedule the next measurement.