### PR TITLE
Always flash under reset

### DIFF
--- a/firmware/.embed.toml
+++ b/firmware/.embed.toml
@@ -17,6 +17,9 @@ enabled = false
 
 # Flash target
 
+[flash.general]
+connect_under_reset = true
+
 [flash.flashing]
 enabled = true
 restore_unwritten_bytes = false


### PR DESCRIPTION
When the microcontroller is in standby, it will not allow attaching.
Thus, we need to attach under reset in those cases.