### PR TITLE
Upgrade RTIC to 1.0.0

### DIFF
--- a/firmware/Cargo.lock
+++ b/firmware/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aligned"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19796bd8d477f1a9d4ac2465b464a8b1359474f06a96bb3cda650b4fca309bf"
+checksum = "3a785a543aea40f5e4e2e93bb2655d31bc21bb391fff65697150973e383f16bb"
 dependencies = [
  "as-slice 0.1.5",
 ]
@@ -67,11 +67,11 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cast"
-version = "0.2.3"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0"
+checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
 dependencies = [
- "rustc_version 0.2.3",
+ "rustc_version 0.4.0",
 ]
 
 [[package]]
@@ -99,15 +99,15 @@ dependencies = [
  "aligned",
  "bare-metal",
  "bitfield",
- "cortex-m 0.7.2",
+ "cortex-m 0.7.3",
  "volatile-register",
 ]
 
 [[package]]
 name = "cortex-m"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643a210c1bdc23d0db511e2a576082f4ff4dcae9d0c37f50b431b8f8439d6d6b"
+checksum = "2ac919ef424449ec8c08d515590ce15d9262c0ca5f0da5b0c901e971a3b783b3"
 dependencies = [
  "bare-metal",
  "bitfield",
@@ -117,9 +117,9 @@ dependencies = [
 
 [[package]]
 name = "cortex-m-rt"
-version = "0.6.13"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "980c9d0233a909f355ed297ef122f257942de5e0a2cb1c39f60684b65bcb90fb"
+checksum = "454f278bf469e2de0a4d22ea019d169d8944f86957c8207a39e3f66c32be2fc6"
 dependencies = [
  "cortex-m-rt-macros",
  "r0",
@@ -127,9 +127,9 @@ dependencies = [
 
 [[package]]
 name = "cortex-m-rt-macros"
-version = "0.1.8"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4717562afbba06e760d34451919f5c3bf3ac15c7bb897e8b04862a7428378647"
+checksum = "c8e3aa52243e26f5922fa522b0814019e0c98fc567e2756d715dce7ad7a81f49"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -138,12 +138,11 @@ dependencies = [
 
 [[package]]
 name = "cortex-m-rtic"
-version = "0.5.6"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa43f63284b363ac64f9ce5221a0f593b54f73258aba8e1a88c1feed8efdb664"
+checksum = "fb77bb72c171d0aa52a2954d8dc7e3f0800ab54b8df7d826f138abbea9eb2794"
 dependencies = [
  "cortex-m 0.6.7",
- "cortex-m-rt",
  "cortex-m-rtic-macros",
  "heapless",
  "rtic-core",
@@ -152,9 +151,9 @@ dependencies = [
 
 [[package]]
 name = "cortex-m-rtic-macros"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1a6a4c9550373038c0e21a78d44d529bd697c25bbf6b8004bddc6e63b119c7"
+checksum = "cc874eda99515b15e67f03562726a530388f454431096d30131051b52b840559"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -168,7 +167,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bffa6c1454368a6aa4811ae60964c38e6996d397ff8095a8b9211b1c1f749bc"
 dependencies = [
- "cortex-m 0.7.2",
+ "cortex-m 0.7.3",
 ]
 
 [[package]]
@@ -179,9 +178,9 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "embedded-hal"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa998ce59ec9765d15216393af37a58961ddcefb14c753b4816ba2191d865fcb"
+checksum = "e36cfb62ff156596c892272f3015ef952fe1525e85261fa3a7f327bd6b384ab9"
 dependencies = [
  "nb 0.1.3",
  "void",
@@ -236,7 +235,7 @@ name = "gfroerli-firmware"
 version = "0.2.0"
 dependencies = [
  "bitfield",
- "cortex-m 0.7.2",
+ "cortex-m 0.7.3",
  "cortex-m-rt",
  "cortex-m-rtic",
  "embedded-hal",
@@ -261,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heapless"
@@ -279,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
+checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -367,9 +366,9 @@ dependencies = [
 
 [[package]]
 name = "numtoa"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e521b6adefa0b2c1fa5d2abdf9a5216288686fe6146249215d884c0e5ab320b0"
+checksum = "6aa2c4e539b869820a2b82e1aef6ff40aa85e65decdd5185e83fb4b1249cd00f"
 
 [[package]]
 name = "one-wire-bus"
@@ -386,23 +385,23 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32bb382689ecd2c4d2d4df9fd56700ba8d43b7b31cca11018cc0e6f8aef39fd5"
 dependencies = [
- "cortex-m 0.7.2",
+ "cortex-m 0.7.3",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.33"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb37d2df5df740e582f28f8560cf425f52bb267d872fe58358eadb554909f07a"
+checksum = "2f84e92c0f7c9d58328b85a78557813e4bd845130db68d7184635344399423b1"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
  "proc-macro2",
 ]
@@ -525,7 +524,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed7ffdb929148070435dbc4dc69fd62b3a031c0543b4a9d2ec9fc8b31a0f3344"
 dependencies = [
  "bare-metal",
- "cortex-m 0.7.2",
+ "cortex-m 0.7.3",
  "cortex-m-rt",
  "vcell",
 ]
@@ -538,7 +537,7 @@ checksum = "795b63c22675365ba0cb6d9bd3b8aca86e1704b9d4a527c6301f9f259a15cbaf"
 dependencies = [
  "as-slice 0.2.1",
  "cast",
- "cortex-m 0.7.2",
+ "cortex-m 0.7.3",
  "cortex-m-rt",
  "cortex-m-semihosting",
  "embedded-hal",
@@ -562,15 +561,15 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
+checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "vcell"
@@ -592,9 +591,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "volatile-register"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d67cb4616d99b940db1d6bd28844ff97108b498a6ca850e5b6191a532063286"
+checksum = "9ee8f19f9d74293faf70901bc20ad067dc1ad390d2cbf1e3f75f721ffee908b6"
 dependencies = [
  "vcell",
 ]

--- a/firmware/Cargo.lock
+++ b/firmware/Cargo.lock
@@ -208,6 +208,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fugit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a100ebf2aadd97481fce0b1265ea470460578ac5441fd9d624e8170753f51a9f"
+
+[[package]]
 name = "gfroerli-common"
 version = "0.1.0"
 dependencies = [
@@ -224,6 +230,7 @@ dependencies = [
  "cortex-m-rtic",
  "embedded-hal",
  "embedded-time",
+ "fugit",
  "gfroerli-common",
  "one-wire-bus",
  "panic-persist",

--- a/firmware/Cargo.lock
+++ b/firmware/Cargo.lock
@@ -3,24 +3,12 @@
 version = 3
 
 [[package]]
-name = "aligned"
-version = "0.3.5"
+name = "aho-corasick"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a785a543aea40f5e4e2e93bb2655d31bc21bb391fff65697150973e383f16bb"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
- "as-slice 0.1.5",
-]
-
-[[package]]
-name = "as-slice"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45403b49e3954a4b8428a0ac21a4b7afadccf92bfd96273f1a58cd4812496ae0"
-dependencies = [
- "generic-array 0.12.4",
- "generic-array 0.13.3",
- "generic-array 0.14.4",
- "stable_deref_trait",
+ "memchr",
 ]
 
 [[package]]
@@ -30,6 +18,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
 dependencies = [
  "stable_deref_trait",
+]
+
+[[package]]
+name = "atomic-polyfill"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686d748538a32325b28d6411dd8a939e7ad5128e5d0023cc4fd3573db456042"
+dependencies = [
+ "critical-section",
+ "riscv-target",
 ]
 
 [[package]]
@@ -48,10 +46,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "bare-metal"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fe8f5a8a398345e52358e18ff07cc17a568fbca5c6f73873d3a62056309603"
+
+[[package]]
 name = "base16"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d27c3610c36aee21ce8ac510e6224498de4228ad772a171ed65643a24693a5a8"
+
+[[package]]
+name = "bit_field"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb6dd1c2376d2e096796e234a70e17e94cc2d5d54ff8ce42b28cef1d0d359a4"
 
 [[package]]
 name = "bitfield"
@@ -92,24 +102,11 @@ dependencies = [
 
 [[package]]
 name = "cortex-m"
-version = "0.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9075300b07c6a56263b9b582c214d0ff037b00d45ec9fde1cc711490c56f1bb9"
-dependencies = [
- "aligned",
- "bare-metal",
- "bitfield",
- "cortex-m 0.7.3",
- "volatile-register",
-]
-
-[[package]]
-name = "cortex-m"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ac919ef424449ec8c08d515590ce15d9262c0ca5f0da5b0c901e971a3b783b3"
 dependencies = [
- "bare-metal",
+ "bare-metal 0.2.5",
  "bitfield",
  "embedded-hal",
  "volatile-register",
@@ -138,23 +135,26 @@ dependencies = [
 
 [[package]]
 name = "cortex-m-rtic"
-version = "0.5.9"
+version = "0.6.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb77bb72c171d0aa52a2954d8dc7e3f0800ab54b8df7d826f138abbea9eb2794"
+checksum = "e8a39a6cfe367f56464ea089489c8ce8a0d14ad0e6dd7bc3770050bb1785ce02"
 dependencies = [
- "cortex-m 0.6.7",
+ "bare-metal 1.0.0",
+ "cortex-m",
  "cortex-m-rtic-macros",
  "heapless",
  "rtic-core",
+ "rtic-monotonic",
  "version_check",
 ]
 
 [[package]]
 name = "cortex-m-rtic-macros"
-version = "0.5.3"
+version = "0.6.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc874eda99515b15e67f03562726a530388f454431096d30131051b52b840559"
+checksum = "1794cde3951be8de7c9e41a4ff6c4ebeca9d1adb2a053513f64061803d6cae92"
 dependencies = [
+ "proc-macro-error",
  "proc-macro2",
  "quote",
  "rtic-syntax",
@@ -167,7 +167,19 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bffa6c1454368a6aa4811ae60964c38e6996d397ff8095a8b9211b1c1f749bc"
 dependencies = [
- "cortex-m 0.7.3",
+ "cortex-m",
+]
+
+[[package]]
+name = "critical-section"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01e191a5a6f6edad9b679777ef6b6c0f2bdd4a333f2ecb8f61c3e28109a03d70"
+dependencies = [
+ "bare-metal 1.0.0",
+ "cfg-if",
+ "cortex-m",
+ "riscv",
 ]
 
 [[package]]
@@ -196,34 +208,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
-dependencies = [
- "typenum",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f797e67af32588215eaaab8327027ee8e71b9dd0b2b26996aedf20c030fce309"
-dependencies = [
- "typenum",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "gfroerli-common"
 version = "0.1.0"
 dependencies = [
@@ -235,7 +219,7 @@ name = "gfroerli-firmware"
 version = "0.2.0"
 dependencies = [
  "bitfield",
- "cortex-m 0.7.3",
+ "cortex-m",
  "cortex-m-rt",
  "cortex-m-rtic",
  "embedded-hal",
@@ -251,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "hash32"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4041af86e63ac4298ce40e5cca669066e75b6f1aa3390fe2561ffa5e1d9f4cc"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
 dependencies = [
  "byteorder",
 ]
@@ -266,13 +250,13 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heapless"
-version = "0.6.1"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634bd4d29cbf24424d0a4bfcbf80c6960129dc24424752a7d1d1390607023422"
+checksum = "9c1ad878e07405df82b695089e63d278244344f80e764074d0bdfe99b89460f3"
 dependencies = [
- "as-slice 0.1.5",
- "generic-array 0.14.4",
+ "atomic-polyfill",
  "hash32",
+ "spin",
  "stable_deref_trait",
 ]
 
@@ -285,6 +269,27 @@ dependencies = [
  "autocfg",
  "hashbrown",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lock_api"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "memchr"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "nb"
@@ -385,7 +390,31 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32bb382689ecd2c4d2d4df9fd56700ba8d43b7b31cca11018cc0e6f8aef39fd5"
 dependencies = [
- "cortex-m 0.7.3",
+ "cortex-m",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -411,6 +440,44 @@ name = "r0"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2a38df5b15c8d5c7e8654189744d8e396bddc18ad48041a500ce52d6948941f"
+
+[[package]]
+name = "regex"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "riscv"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6907ccdd7a31012b70faf2af85cd9e5ba97657cc3987c4f13f8e4d2c2a088aba"
+dependencies = [
+ "bare-metal 1.0.0",
+ "bit_field",
+ "riscv-target",
+]
+
+[[package]]
+name = "riscv-target"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88aa938cda42a0cf62a20cfe8d139ff1af20c2e681212b5b34adb5a58333f222"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
 
 [[package]]
 name = "rn2xx3"
@@ -454,13 +521,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bd58a6949de8ff797a346a28d9f13f7b8f54fa61bb5e3cb0985a4efb497a5ef"
 
 [[package]]
-name = "rtic-syntax"
-version = "0.4.0"
+name = "rtic-monotonic"
+version = "0.1.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8152fcaa845720d61e6cc570548b89144c2c307f18a480bbd97e55e9f6eeff04"
+checksum = "7e019d674efea87f510f6857e8a381cab2781b415d37d34564440d902eb6c946"
+
+[[package]]
+name = "rtic-syntax"
+version = "0.5.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60670421cd7af9cb6e0562cc093710c634ff6e2374c2d664c82aa315b3c7ea4"
 dependencies = [
  "indexmap",
  "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -481,6 +555,12 @@ checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver 1.0.4",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
@@ -512,6 +592,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -523,8 +612,8 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed7ffdb929148070435dbc4dc69fd62b3a031c0543b4a9d2ec9fc8b31a0f3344"
 dependencies = [
- "bare-metal",
- "cortex-m 0.7.3",
+ "bare-metal 0.2.5",
+ "cortex-m",
  "cortex-m-rt",
  "vcell",
 ]
@@ -535,9 +624,9 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "795b63c22675365ba0cb6d9bd3b8aca86e1704b9d4a527c6301f9f259a15cbaf"
 dependencies = [
- "as-slice 0.2.1",
+ "as-slice",
  "cast",
- "cortex-m 0.7.3",
+ "cortex-m",
  "cortex-m-rt",
  "cortex-m-semihosting",
  "embedded-hal",
@@ -558,12 +647,6 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
-
-[[package]]
-name = "typenum"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
 
 [[package]]
 name = "unicode-xid"

--- a/firmware/Cargo.lock
+++ b/firmware/Cargo.lock
@@ -135,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "cortex-m-rtic"
-version = "0.6.0-rc.4"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a39a6cfe367f56464ea089489c8ce8a0d14ad0e6dd7bc3770050bb1785ce02"
+checksum = "daae9c453d0d5b467ebcdeae7aba537cb45a7de899930ad09f01c8dc42aa531f"
 dependencies = [
  "bare-metal 1.0.0",
  "cortex-m",
@@ -150,9 +150,9 @@ dependencies = [
 
 [[package]]
 name = "cortex-m-rtic-macros"
-version = "0.6.0-rc.4"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1794cde3951be8de7c9e41a4ff6c4ebeca9d1adb2a053513f64061803d6cae92"
+checksum = "7ba355d1639cf8df7c0658f01bd8952d11d49a029309118787eb54afc47a6cf8"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -522,21 +522,21 @@ dependencies = [
 
 [[package]]
 name = "rtic-core"
-version = "0.3.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bd58a6949de8ff797a346a28d9f13f7b8f54fa61bb5e3cb0985a4efb497a5ef"
+checksum = "d9369355b04d06a3780ec0f51ea2d225624db777acbc60abd8ca4832da5c1a42"
 
 [[package]]
 name = "rtic-monotonic"
-version = "0.1.0-rc.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e019d674efea87f510f6857e8a381cab2781b415d37d34564440d902eb6c946"
+checksum = "fb8b0b822d1a366470b9cea83a1d4e788392db763539dc4ba022bcc787fece82"
 
 [[package]]
 name = "rtic-syntax"
-version = "0.5.0-rc.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60670421cd7af9cb6e0562cc093710c634ff6e2374c2d664c82aa315b3c7ea4"
+checksum = "24b149ff3177daeee442bb81ef7867d20d3c1ffea8a0a94e46e0e4b876ec4be2"
 dependencies = [
  "indexmap",
  "proc-macro2",

--- a/firmware/Cargo.lock
+++ b/firmware/Cargo.lock
@@ -226,7 +226,6 @@ version = "0.2.0"
 dependencies = [
  "bitfield",
  "cortex-m",
- "cortex-m-rt",
  "cortex-m-rtic",
  "embedded-hal",
  "embedded-time",

--- a/firmware/Cargo.toml
+++ b/firmware/Cargo.toml
@@ -18,7 +18,7 @@ gfroerli-common = { path = "../common" }
 bitfield = "0.13"
 cortex-m = "0.7" # Keep in sync with stm32l0xx-hal
 cortex-m-rt = "0.6.8" # Keep in sync with stm32l0xx-hal
-cortex-m-rtic = "0.5"
+cortex-m-rtic = "0.6.0-rc.4"
 embedded-hal = { version = "0.2.3", features = ["unproven"] } # Keep in sync with stm32l0xx-hal
 embedded-time = "0.12" # Keep in sync with stm32l0xx-hal
 one-wire-bus = "0.1.1"

--- a/firmware/Cargo.toml
+++ b/firmware/Cargo.toml
@@ -17,7 +17,7 @@ gfroerli-common = { path = "../common" }
 
 bitfield = "0.13"
 cortex-m = "0.7" # Keep in sync with stm32l0xx-hal
-cortex-m-rtic = "0.6.0-rc.4"
+cortex-m-rtic = "1.0.0"
 embedded-hal = { version = "0.2.3", features = ["unproven"] } # Keep in sync with stm32l0xx-hal
 embedded-time = "0.12" # Keep in sync with stm32l0xx-hal
 fugit = "0.3"

--- a/firmware/Cargo.toml
+++ b/firmware/Cargo.toml
@@ -21,6 +21,7 @@ cortex-m-rt = "0.6.8" # Keep in sync with stm32l0xx-hal
 cortex-m-rtic = "0.6.0-rc.4"
 embedded-hal = { version = "0.2.3", features = ["unproven"] } # Keep in sync with stm32l0xx-hal
 embedded-time = "0.12" # Keep in sync with stm32l0xx-hal
+fugit = "0.3"
 one-wire-bus = "0.1.1"
 rn2xx3 = "0.2.1"
 stm32l0xx-hal = { version = "0.8.0", features = ["rt", "mcu-STM32L071KBTx", "rtc"] }

--- a/firmware/Cargo.toml
+++ b/firmware/Cargo.toml
@@ -17,7 +17,6 @@ gfroerli-common = { path = "../common" }
 
 bitfield = "0.13"
 cortex-m = "0.7" # Keep in sync with stm32l0xx-hal
-cortex-m-rt = "0.6.8" # Keep in sync with stm32l0xx-hal
 cortex-m-rtic = "0.6.0-rc.4"
 embedded-hal = { version = "0.2.3", features = ["unproven"] } # Keep in sync with stm32l0xx-hal
 embedded-time = "0.12" # Keep in sync with stm32l0xx-hal

--- a/firmware/examples/delay.rs
+++ b/firmware/examples/delay.rs
@@ -1,19 +1,25 @@
-//! Toggle the serial TX pin. Useful for verifying the delay implementation using a
-//! logic analyzer.
+//! Toggle the serial TX pin. Useful for verifying the delay implementation
+//! using a logic analyzer.
 
 #![no_main]
 #![no_std]
 
 use panic_persist as _;
-use rtic::app;
-use stm32l0xx_hal::{self as hal, pac, prelude::*};
 
-use gfroerli_firmware::delay;
+#[rtic::app(device = stm32l0xx_hal::pac, peripherals = true)]
+mod app {
+    use stm32l0xx_hal::{self as hal, pac, prelude::*};
 
-#[app(device = stm32l0xx_hal::pac, peripherals = true)]
-const APP: () = {
+    use gfroerli_firmware::delay;
+
+    #[shared]
+    struct SharedResources {}
+
+    #[local]
+    struct LocalResources {}
+
     #[init]
-    fn init(ctx: init::Context) {
+    fn init(ctx: init::Context) -> (SharedResources, LocalResources, init::Monotonics) {
         let mut dp: pac::Peripherals = ctx.device;
 
         // Delay provider
@@ -45,5 +51,7 @@ const APP: () = {
             pin.set_high().unwrap();
             delay.delay_ms(i);
         }
+
+        (SharedResources {}, LocalResources {}, init::Monotonics())
     }
-};
+}

--- a/firmware/src/monotonic_stm32l0.rs
+++ b/firmware/src/monotonic_stm32l0.rs
@@ -1,99 +1,102 @@
-//! Using STM32L0 TIM6 as monotonic 16 bit timer.
+//! RTIC Monotonic implementation for STM32L0 16-bit timers.
 //!
-//! ## Prescaler Calculations
+//! The 16-bit timer is software-extended to 32 bit by incrementing an overflow
+//! counter every time the timer overflows. At an LSE frequency of 32.768 kHz,
+//! an overflow will happen every 2 seconds.
 //!
-//! This implementation assumes that the core clock is set to 16 MHz (see
-//! `CORE_CLOCK` constant). At 16 MHz, this means 62.5 ns per clock cycle.
-//!
-//! If we use a prescaler value of 2000, that means 62.5 ns * 2000 = 125 µs per
-//! timer tick. This corresponds to a frequency of 16 MHz / 2000 = 8.0 kHz.
-//!
-//! Because the timer has 16 bits, it will overflow every 125 µs * 2^16 =
-//! ~8.19 seconds. Due to overflow checking, we can only safely use one
-//! half of the available timer range, meaning that we can safely schedule
-//! tasks 4.096 seconds into the future, with a resolution of 125 µs.
+//! Note: There might be power-saving potential by not extending the timer
+//! (less interrupts), but we'd have to measure whether it's relevant or not.
 
-use core::{
-    cmp::Ordering,
-    convert::{Infallible, TryInto},
-    fmt, ops, u32,
-};
+use core::u32;
+
+pub use fugit::ExtU32;
 use rtic::Monotonic;
 use stm32l0xx_hal::pac;
 
-/// Implementor of the `rtic::Monotonic` traits and used to consume the timer
-/// to not allow for erroneous configuration.
-///
-/// This uses TIM6 internally.
-pub struct Tim6Monotonic;
+const LSE_FREQ: u32 = 32_768;
 
-// Note: Adjusting CORE_CLOCK or PRESCALER may cause the calculations
-// in `U16Ext` to overflow their data types. Check them to ensure that
-// it can't happen.
-const CORE_CLOCK: u32 = 16_000_000;
-const PRESCALER: u32 = 2000;
-const HZ: u32 = CORE_CLOCK / PRESCALER;
+/// Software-extended LPTIM.
+pub struct ExtendedLptim<TIM> {
+    timer: TIM,
+    overflow: u16,
+}
 
-impl Tim6Monotonic {
-    /// Initialize the timer instance.
-    pub fn init(timer: pac::TIM6) -> Self {
-        // Enable and reset TIM6 in RCC
+impl ExtendedLptim<pac::LPTIM> {
+    pub fn init(timer: pac::LPTIM) -> Self {
+        // Enable and reset LPTIM in RCC
         //
-        // Correctness: Since we only modify TIM6 related registers in the RCC
-        // register block, and since we own pac::TIM6, we should be safe.
+        // Correctness: Since we only modify LPTIM related registers in the RCC
+        // register block, and since we own pac::LPTIM, we should be safe.
         unsafe {
             let rcc = &*pac::RCC::ptr();
 
-            // Enable timer
-            rcc.apb1enr.modify(|_, w| w.tim6en().set_bit());
+            // Select clock source: LSE
+            rcc.ccipr.modify(|_, w| w.lptim1sel().lse());
+
+            // Enable timer clock
+            rcc.apb1enr.modify(|_, w| w.lptim1en().set_bit());
 
             // Reset timer
-            rcc.apb1rstr.modify(|_, w| w.tim6rst().set_bit());
-            rcc.apb1rstr.modify(|_, w| w.tim6rst().clear_bit());
+            rcc.apb1rstr.modify(|_, w| w.lptim1rst().set_bit());
+            rcc.apb1rstr.modify(|_, w| w.lptim1rst().clear_bit());
         }
 
-        // Set up prescaler
-        timer.psc.write(|w| w.psc().bits(PRESCALER as u16));
+        // Enable the compare-match interrupt
+        timer.ier.modify(|_, w| w.cmpmie().set_bit());
 
-        // Enable counter
-        timer.cr1.modify(|_, w| w.cen().set_bit());
+        Self { timer, overflow: 0 }
+    }
 
-        // Explicitly drop timer instance so it cannot be reused or reconfigured
-        drop(timer);
+    fn is_overflow(&self) -> bool {
+        // Return whether the ARRM (Autoreload match) flag in the ISR
+        // (interrupt and status register) is set.
+        self.timer.isr.read().arrm().bit_is_set()
+    }
 
-        Tim6Monotonic
+    fn clear_overflow_flag(&self) {
+        self.timer.icr.write(|w| w.arrmcf().set_bit());
     }
 }
 
-impl Monotonic for Tim6Monotonic {
-    type Instant = Instant;
-    type Duration = Duration;
+impl Monotonic for ExtendedLptim<pac::LPTIM> {
+    // Since we are counting overflows we can't let RTIC disable the interrupt.
+    const DISABLE_INTERRUPT_ON_EMPTY_QUEUE: bool = false;
 
-    /// For now, do not allow RTIC to disable the interrupt when the queue is
-    /// empty. It's an optimization option for the future though.
-    const DISABLE_INTERRUPT_ON_EMPTY_QUEUE: bool = true;
+    type Instant = fugit::TimerInstantU32<LSE_FREQ>;
+    type Duration = fugit::TimerDurationU32<LSE_FREQ>;
 
     /// Return the current time.
+    #[inline(always)]
     fn now(&mut self) -> Self::Instant {
-        Instant::now()
-    }
+        // Note: The reference manual contains this text:s
+        //
+        // > It should be noted that for a reliable LPTIM_CNT register read
+        // > access, two consecutive read accesses must be performed and
+        // > compared. A read access can be considered reliable when the values
+        // > of the two consecutive read accesses are equal.
+        //
+        // However, I think this only applies to asynchronous mode with an
+        // external clock source.
+        let counter = self.timer.cnt.read().cnt().bits() as u32;
 
-    /// Set the compare value of the timer interrupt.
-    fn set_compare(&mut self, _instant: Self::Instant) {
-        todo!("Called set_compare");
-    }
+        // If the overflow bit is set, it means that `on_interrupt` (which
+        // clears the flag) was not yet called. Compensate for this.
+        let overflow = if self.is_overflow() {
+            self.overflow + 1
+        } else {
+            self.overflow
+        } as u32;
 
-    /// Clear the compare interrupt flag.
-    fn clear_compare_flag(&mut self) {
-        todo!("Called clear_compare_flag");
+        Self::Instant::from_ticks(overflow * (1 << 16) + counter)
     }
 
     /// The time at time zero. Used by RTIC before the monotonic has been initialized.
+    #[inline(always)]
     fn zero() -> Self::Instant {
-        Instant { inner: 0 }
+        Self::Instant::from_ticks(0)
     }
 
-    /// Optionally resets the counter to zero for a fixed baseline in a system.
+    /// Reset the counter to zero for a fixed baseline in a system.
     ///
     /// This method will be called exactly once by the RTIC runtime after
     /// `#[init]` returns and before tasks start.
@@ -102,226 +105,53 @@ impl Monotonic for Tim6Monotonic {
     ///
     /// The user may not call this method.
     unsafe fn reset(&mut self) {
-        let tim = &*pac::TIM6::ptr();
+        // Enable LPTIM
+        self.timer.cr.modify(|_, w| w.enable().set_bit());
 
-        // Pause
-        tim.cr1.modify(|_, w| w.cen().clear_bit());
-        // Reset counter
-        tim.cnt.reset();
-        // Continue
-        tim.cr1.modify(|_, w| w.cen().set_bit());
+        // Set the autoreload register to the max value
+        self.timer.arr.write(|w| w.bits(0xffff));
+
+        // Start counting
+        self.timer.cr.modify(|_, w| w.cntstrt().set_bit());
     }
-}
 
-/// A measurement of the counter. Opaque and useful only with `Duration`.
-///
-/// # Correctness
-///
-/// Adding or subtracting a `Duration` of more than `(1 << 15)` cycles to an `Instant` effectively
-/// makes it "wrap around" and creates an incorrect value. This is also true if the operation is
-/// done in steps, e.g. `(instant + dur) + dur` where `dur` is `(1 << 14)` ticks.
-#[derive(Clone, Copy, Eq, PartialEq)]
-pub struct Instant {
-    inner: i16,
-}
+    /// Set the compare value of the timer interrupt.
+    fn set_compare(&mut self, instant: Self::Instant) {
+        let now = self.now();
 
-impl Instant {
-    /// Returns an instant corresponding to "now".
-    pub fn now() -> Self {
-        let now = {
-            let tim = unsafe { &*pac::TIM6::ptr() };
-            tim.cnt.read().cnt().bits()
+        // Since the timer may or may not overflow based on the requested
+        // compare val, we check how many ticks are left.
+        let compare_register_val = match instant.checked_duration_since(now) {
+            // If the scheduled instant is too far in the future, we can't set
+            // an exact deadline because it's too far in the future. Set it to 0,
+            // RTIC will handle re-scheduling.
+            Some(duration) if duration.ticks() > 0xffff => 0,
+
+            // Instant is in the past. RTIC will handle this.
+            None => 0,
+
+            // Value will not overflow the 16-bit register.
+            Some(_) => instant.duration_since_epoch().ticks() as u16,
         };
 
-        Instant { inner: now as i16 }
+        // Write value to compare register
+        self.timer.cmp.write(|w| w.cmp().bits(compare_register_val));
     }
 
-    /// Returns the amount of time elapsed since this instant was created.
-    pub fn elapsed(&self) -> Duration {
-        Instant::now() - *self
+    /// Clear the compare interrupt flag.
+    fn clear_compare_flag(&mut self) {
+        self.timer.icr.write(|w| w.cmpmcf().set_bit());
     }
 
-    /// Returns the underlying count
-    pub fn counts(&self) -> u16 {
-        self.inner as u16
-    }
-
-    /// Returns the amount of time elapsed from another instant to this one.
-    pub fn duration_since(&self, earlier: Instant) -> Duration {
-        let diff = self.inner.wrapping_sub(earlier.inner);
-        assert!(diff >= 0, "second instant is later than self");
-        Duration { inner: diff as u16 }
-    }
-}
-
-impl fmt::Debug for Instant {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("Instant")
-            .field(&(self.inner as u16))
-            .finish()
-    }
-}
-
-impl ops::AddAssign<Duration> for Instant {
-    fn add_assign(&mut self, dur: Duration) {
-        // NOTE this is a debug assertion because there's no foolproof way to detect a wrap around;
-        // the user may write `(instant + dur) + dur` where `dur` is `(1<<15)-1` ticks.
-        debug_assert!(dur.inner < (1 << 15));
-        self.inner = self.inner.wrapping_add(dur.inner as i16);
-    }
-}
-
-impl ops::Add<Duration> for Instant {
-    type Output = Self;
-    fn add(mut self, dur: Duration) -> Self {
-        self += dur;
-        self
-    }
-}
-
-impl ops::SubAssign<Duration> for Instant {
-    fn sub_assign(&mut self, dur: Duration) {
-        // NOTE see the NOTE in `<Instant as AddAssign<Duration>>::add_assign`
-        debug_assert!(dur.inner < (1 << 15));
-        self.inner = self.inner.wrapping_sub(dur.inner as i16);
-    }
-}
-
-impl ops::Sub<Duration> for Instant {
-    type Output = Self;
-    fn sub(mut self, dur: Duration) -> Self {
-        self -= dur;
-        self
-    }
-}
-
-impl ops::Sub for Instant {
-    type Output = Duration;
-    fn sub(self, other: Instant) -> Duration {
-        self.duration_since(other)
-    }
-}
-
-impl Ord for Instant {
-    fn cmp(&self, rhs: &Self) -> Ordering {
-        self.inner.wrapping_sub(rhs.inner).cmp(&0)
-    }
-}
-
-impl PartialOrd for Instant {
-    fn partial_cmp(&self, rhs: &Self) -> Option<Ordering> {
-        Some(self.cmp(rhs))
-    }
-}
-
-/// A `Duration` type to represent a span of time.
-#[derive(Clone, Copy, Default, Eq, Ord, PartialEq, PartialOrd)]
-pub struct Duration {
-    inner: u16,
-}
-
-impl Duration {
-    /// Creates a new `Duration` from the specified number of timer ticks
-    pub fn from_ticks(ticks: u16) -> Self {
-        Duration { inner: ticks }
-    }
-
-    /// Returns the total number of timer ticks contained by this `Duration`
-    pub fn as_ticks(&self) -> u16 {
-        self.inner
-    }
-}
-
-// Used internally by RTIC to convert the duration into a known type
-impl TryInto<u32> for Duration {
-    type Error = Infallible;
-
-    fn try_into(self) -> Result<u32, Infallible> {
-        Ok(self.as_ticks() as u32)
-    }
-}
-
-impl ops::AddAssign for Duration {
-    fn add_assign(&mut self, dur: Duration) {
-        self.inner += dur.inner;
-    }
-}
-
-impl ops::Add for Duration {
-    type Output = Self;
-    fn add(self, other: Self) -> Self {
-        Duration {
-            inner: self.inner + other.inner,
-        }
-    }
-}
-
-impl ops::Mul<u16> for Duration {
-    type Output = Self;
-    fn mul(self, other: u16) -> Self {
-        Duration {
-            inner: self.inner * other,
-        }
-    }
-}
-
-impl ops::MulAssign<u16> for Duration {
-    fn mul_assign(&mut self, other: u16) {
-        *self = *self * other;
-    }
-}
-
-impl ops::SubAssign for Duration {
-    fn sub_assign(&mut self, rhs: Duration) {
-        self.inner -= rhs.inner;
-    }
-}
-
-impl ops::Sub for Duration {
-    type Output = Self;
-    fn sub(self, rhs: Self) -> Self {
-        Duration {
-            inner: self.inner - rhs.inner,
-        }
-    }
-}
-
-/// Adds the `secs`, `millis` and `micros` methods to the `u16` type.
-///
-/// WARNING: You cannot represent values higher than 8192 milliseconds without
-/// overflow!
-pub trait U16Ext {
-    /// Converts the `u16` value as seconds into ticks
-    fn secs(self) -> Duration;
-
-    /// Converts the `u16` value as milliseconds into ticks
-    fn millis(self) -> Duration;
-
-    /// Converts the `u16` value as microseconds into ticks
-    fn micros(self) -> Duration;
-}
-
-impl U16Ext for u16 {
-    fn secs(self) -> Duration {
-        debug_assert!(self <= 8, "Cannot represent values >8s in a `Duration`");
-        Duration {
-            inner: HZ as u16 * self,
-        }
-    }
-
-    fn millis(self) -> Duration {
-        debug_assert!(
-            self <= 8192,
-            "Cannot represent values >8192 in a `Duration`"
-        );
-        Duration {
-            inner: (HZ as u64 * self as u64 / 1_000) as u16,
-        }
-    }
-
-    fn micros(self) -> Duration {
-        Duration {
-            inner: (HZ as u32 * self as u32 / 1_000_000) as u16,
+    /// Optional. Commonly used for performing housekeeping of a timer when it
+    /// has been extended, e.g. a 16 bit timer extended to 32/64 bits. This
+    /// will be called at the end of the interrupt handler after all other
+    /// operations have finished.
+    fn on_interrupt(&mut self) {
+        // If there was an overflow, increment the overflow counter.
+        if self.is_overflow() {
+            self.clear_overflow_flag();
+            self.overflow += 1;
         }
     }
 }


### PR DESCRIPTION
This touched a lot of our code, so it may be hard to review. Except for the monotonic impl, it should be all mechanical changes without change in behavior. It works on my device 😉

- RTIC 1.0 docs: https://rtic.rs/dev/book/en/
- Migration guide: https://rtic.rs/dev/book/en/migration/migration_v5.html

Some relevant changes:

- The monotonic implementation had to be re-done completely.
  - With the new trait, things become simpler, but we cannot use TIM6 anymore because it doesn't have a capture/compare register. Instead, I used LPTIM, which has the advantage that it could be used to schedule tasks while in a low power state, which means that we could further optimize by putting the microcontroller in one of those low-power states when waiting for a scheduled task (but when not yet in standby).
  - LPTIM is configured to use LSE (the external 32.768 kHz crystal) as clock source, making it independent of the core clock. (LSE always works, since we need it for the RTC.)
  - I replaced the custom Instant/Delay implementation with [fugit](https://docs.rs/fugit/).
  - The 16-bit timer is now software-extended to 32 bits using an overflow counter, meaning that we can now schedule tasks more than 4s into the future (and we have 32 kHz tick resolution instead of 8 kHz). This has two tradeoffs: There are additional interrupts (the overflow, but that happens only every 2s) and RTIC cannot disable the timer when no task is scheduled. However, that doesn't matter to us, because either we have scheduled tasks, or we're in standby.
- Resources are now split into shared and local resources. I moved all resources that we only use in a single task to the local resources.