### PR TITLE
Prefix data transmission logs with emoji

### DIFF
--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -587,7 +587,7 @@ const APP: () = {
             let length = message.encode(&mut buf);
 
             // Transmit
-            writeln!(ctx.resources.debug, "Transmitting measurement...").unwrap();
+            writeln!(ctx.resources.debug, "📣 Transmitting measurement...").unwrap();
             let tx_result = ctx.resources.rn.transmit_slice(
                 ConfirmationMode::Unconfirmed,
                 fport,


### PR DESCRIPTION
Makes it easier to spot in the log.

![screenshot-20211222-235526](https://user-images.githubusercontent.com/105168/147164142-f304f922-4d84-4e58-9e92-32340bb72f19.png)
