### PR TITLE
Add supply monitor example

### DIFF
--- a/firmware/Cargo.lock
+++ b/firmware/Cargo.lock
@@ -226,6 +226,7 @@ version = "0.2.0"
 dependencies = [
  "bitfield",
  "cortex-m",
+ "cortex-m-rt",
  "cortex-m-rtic",
  "embedded-hal",
  "embedded-time",

--- a/firmware/Cargo.toml
+++ b/firmware/Cargo.toml
@@ -17,6 +17,7 @@ gfroerli-common = { path = "../common" }
 
 bitfield = "0.13"
 cortex-m = "0.7" # Keep in sync with stm32l0xx-hal
+cortex-m-rt = "0.6.15"
 cortex-m-rtic = "1.0.0"
 embedded-hal = { version = "0.2.3", features = ["unproven"] } # Keep in sync with stm32l0xx-hal
 embedded-time = "0.12" # Keep in sync with stm32l0xx-hal

--- a/firmware/Cargo.toml
+++ b/firmware/Cargo.toml
@@ -17,7 +17,6 @@ gfroerli-common = { path = "../common" }
 
 bitfield = "0.13"
 cortex-m = "0.7" # Keep in sync with stm32l0xx-hal
-cortex-m-rt = "0.6.15"
 cortex-m-rtic = "1.0.0"
 embedded-hal = { version = "0.2.3", features = ["unproven"] } # Keep in sync with stm32l0xx-hal
 embedded-time = "0.12" # Keep in sync with stm32l0xx-hal
@@ -29,6 +28,7 @@ shtcx = { git = "https://github.com/dbrgn/shtcx-rs", branch = "master" }
 
 [dev-dependencies]
 rstest = "0.11"
+cortex-m-rt = "0.6.15" # Keep in sync with stm32l0xx-hal. Used in example
 
 [target.'cfg(target_arch = "arm")'.dependencies]
 panic-persist = { version = "0.3.0", features = ["utf8"] }

--- a/firmware/examples/supply_monitor.rs
+++ b/firmware/examples/supply_monitor.rs
@@ -1,0 +1,73 @@
+//! Prints the supply voltage monitor output to the serial port.
+#![no_main]
+#![no_std]
+
+use panic_persist as _;
+
+use core::fmt::Write;
+
+use cortex_m_rt::entry;
+use embedded_time::rate::Baud;
+use hal::serial;
+use stm32l0xx_hal as hal;
+use stm32l0xx_hal::prelude::*;
+
+use gfroerli_firmware::supply_monitor;
+
+#[entry]
+fn main() -> ! {
+    let p = cortex_m::Peripherals::take().unwrap();
+    let dp = stm32l0xx_hal::pac::Peripherals::take().unwrap();
+
+    let syst = p.SYST;
+    let mut rcc = dp.RCC.freeze(hal::rcc::Config::hsi16());
+    let mut delay = hal::delay::Delay::new(syst, rcc.clocks);
+
+    let gpiob = dp.GPIOB.split(&mut rcc);
+    let mut led = gpiob.pb3.into_push_pull_output();
+
+    let gpioa = dp.GPIOA.split(&mut rcc);
+
+    let mut serial = hal::serial::Serial::usart1(
+        dp.USART1,
+        gpiob.pb6.into_floating_input(),
+        gpiob.pb7.into_floating_input(),
+        serial::Config {
+            baudrate: Baud(57_600),
+            wordlength: serial::WordLength::DataBits8,
+            parity: serial::Parity::ParityNone,
+            stopbits: serial::StopBits::STOP1,
+        },
+        &mut rcc,
+    )
+    .unwrap();
+
+    writeln!(serial, "Starting supply_monitor example").unwrap();
+
+    // Initialize supply monitor
+    let adc = dp.ADC.constrain(&mut rcc);
+
+    let a1 = gpioa.pa1.into_analog();
+    let adc_enable_pin = gpioa.pa5.into_push_pull_output().downgrade();
+    let mut supply_monitor = supply_monitor::SupplyMonitor::new(a1, adc, adc_enable_pin);
+
+    loop {
+        let v_supply = supply_monitor.read_supply_raw();
+        if let Some(v_supply_raw) = v_supply {
+            let v_input = (v_supply_raw as f32) / 4095.0 * 3.3;
+            let v_supply_converted = supply_monitor::SupplyMonitor::convert_input(v_supply_raw);
+
+            writeln!(
+                serial,
+                "Raw: {} ({}) -> Supply: {}",
+                v_supply_raw, v_input, v_supply_converted
+            )
+            .unwrap();
+        }
+
+        led.set_high().unwrap();
+        delay.delay_ms(1_000u16);
+        led.set_low().unwrap();
+        delay.delay_ms(1_000u16);
+    }
+}


### PR DESCRIPTION
This is the base example which works with the current code. This can be merged until #128 with the actual supply monitor improvements is ready.